### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployVsCodeExtension.yml
+++ b/.github/workflows/deployVsCodeExtension.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - master
 name: Deploy vsCode Extension
+permissions:
+  contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mpearon/vsce.show-TriggerWords/security/code-scanning/2](https://github.com/mpearon/vsce.show-TriggerWords/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/deployVsCodeExtension.yml`.  
Best single fix (without changing functional intent): define workflow-level permissions right after `name`, granting only what this workflow needs.

Given the current steps:
- `actions/checkout` requires `contents: read`.
- `phips28/gh-action-bump-version` typically commits/tags and pushes, so it needs `contents: write`.

So the safest least-privilege fix for existing behavior is:
```yml
permissions:
  contents: write
```
This scopes `GITHUB_TOKEN` explicitly and preserves expected bump/tag behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
