### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   call_public_vsce_build_action:
     uses: mpearon/public-workflows/.github/workflows/vsce-extension-BuildPublish.yml@main


### PR DESCRIPTION
Potential fix for [https://github.com/mpearon/vsce.show-TriggerWords/security/code-scanning/1](https://github.com/mpearon/vsce.show-TriggerWords/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/main.yml` at the workflow root (recommended for reusable workflow calls unless job-specific overrides are needed).  
Use least privilege as a safe baseline:

- `contents: read` (commonly needed for checkout/read operations)
- `packages: read` (common minimal read for package access if needed)

This keeps behavior unchanged while preventing implicit broad token scopes from defaults. Place the block after the `on:` section and before `jobs:` so it applies to all jobs (including the reusable workflow call job) unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
